### PR TITLE
make use of recursive option in hiera.yaml

### DIFF
--- a/lib/puppet/functions/hiera_ssm_paramstore.rb
+++ b/lib/puppet/functions/hiera_ssm_paramstore.rb
@@ -57,6 +57,7 @@ Puppet::Functions.create_function(:hiera_ssm_paramstore) do
         data = ssmclient.get_parameters_by_path({
           path: options['uri'],
           with_decryption: true,
+          recursive: options['recursive'],
           next_token: token
         })
         context.explain { "Adding keys on cache ..." }


### PR DESCRIPTION
Currently options['recursive'] is not used in the ssm.get_parameters_by_path. simple change to allow this.