### PR TITLE
translate :: from standard module::key hiera data into a /

### DIFF
--- a/lib/puppet/functions/hiera_ssm_paramstore.rb
+++ b/lib/puppet/functions/hiera_ssm_paramstore.rb
@@ -12,7 +12,7 @@ Puppet::Functions.create_function(:hiera_ssm_paramstore) do
   end
 
   def lookup_key(key, options, context)
-    key_path = context.interpolate(options['uri'] + key)
+    key_path = context.interpolate(options['uri'] + key.gsub('::', '/'))
 
     # Searches for key and key path due to ssm return just the key for keys on the root path (/)
     # and the full path for the rest (/path/key)


### PR DESCRIPTION
This will allow existing hiera data for most modules to be capable of being placed in SSM.
SSM doesnt support : in its keys.
So by creating ssm key test/foo, it can be referenced in hiera as lookup('test::foo')