### PR TITLE
Fix spec function test so they play nicely with class etc tests

### DIFF
--- a/spec/functions/hiera_ssm_paramstore_spec.rb
+++ b/spec/functions/hiera_ssm_paramstore_spec.rb
@@ -1,10 +1,7 @@
 require 'spec_helper'
 
-require 'puppet/functions/hiera_ssm_paramstore'
-
-describe TF do # rubocop:disable RSpec/FilePath
-  let(:function) { described_class.new }
-  let(:context) { instance_double('Puppet::LookupContext') }
+describe 'hiera_ssm_paramstore' do
+  let(:context) { Puppet::Pops::Lookup::Context.new('m', 'm') }
 
   before(:each) do
     allow(context).to receive(:cache_has_key)
@@ -26,29 +23,29 @@ describe TF do # rubocop:disable RSpec/FilePath
 
       it 'find string' do
         expect(context).to receive(:interpolate).with('/plain').and_return('/plain')
-        expect(function.lookup_key('plain', options, context)).to eq('value_plain')
+        is_expected.to run.with_params('plain', options, context).and_return('value_plain')
       end
 
       it 'find secure string' do
         expect(context).to receive(:interpolate).with('/encrypted').and_return('/encrypted')
-        expect(function.lookup_key('encrypted', options, context)).to eq('value_encrypted')
+        is_expected.to run.with_params('encrypted', options, context).and_return('value_encrypted')
       end
 
       it 'not find value' do
         expect(context).to receive(:interpolate).with('/nonexists').and_return('/nonexists')
         expect(context).to receive(:not_found)
-        expect(function.lookup_key('nonexists', options, context)).to eq(nil)
+        is_expected.to run.with_params('nonexists', options, context).and_return(nil)
       end
 
       it 'find string using another region' do
         options['region'] = 'us-east-2'
         expect(context).to receive(:interpolate).with('/region2').and_return('/region2')
-        expect(function.lookup_key('region2', options, context)).to eq('ohio')
+        is_expected.to run.with_params('region2', options, context).and_return('ohio')
       end
 
       it 'find translate string' do
         expect(context).to receive(:interpolate).with('/plain/translate').and_return('/plain/translate')
-        expect(function.lookup_key('plain::translate', options, context)).to eq('parameter_value')
+        is_expected.to run.with_params('plain::translate', options, context).and_return('parameter_value')
       end
       context 'Should run fetching all keys' do
         let(:options) do
@@ -65,7 +62,7 @@ describe TF do # rubocop:disable RSpec/FilePath
           allow(context).to receive(:cache).with('plain' => 'value_plain')
           expect(context).to receive(:cached_value).with('plain').and_return('value_plain')
           expect(context).to receive(:cache_has_key).with('plain').and_return(true)
-          expect(function.lookup_key('plain', options, context)).to eq('value_plain')
+          is_expected.to run.with_params('plain', options, context).and_return('value_plain')
         end
 
         it 'find secure string' do
@@ -73,14 +70,14 @@ describe TF do # rubocop:disable RSpec/FilePath
           allow(context).to receive(:cache).with('encrypted' => 'value_encrypted')
           expect(context).to receive(:cached_value).with('encrypted').and_return('value_encrypted')
           expect(context).to receive(:cache_has_key).with('encrypted').and_return(true)
-          expect(function.lookup_key('encrypted', options, context)).to eq('value_encrypted')
+          is_expected.to run.with_params('encrypted', options, context).and_return('value_encrypted')
         end
 
         it 'not find value' do
           expect(context).to receive(:interpolate).with('/nonexists').and_return('/nonexists')
           expect(context).to receive(:cache_has_key).with('nonexists').and_return(false)
           expect(context).to receive(:not_found)
-          expect(function.lookup_key('nonexists', options, context)).to eq(nil)
+          is_expected.to run.with_params('nonexists', options, context).and_return(nil)
         end
 
         it 'find string full path' do
@@ -89,7 +86,7 @@ describe TF do # rubocop:disable RSpec/FilePath
           allow(context).to receive(:cache).with('/hiera/path' => 'fullpath')
           expect(context).to receive(:cached_value).with('/hiera/path').and_return('fullpath')
           expect(context).to receive(:cache_has_key).with('/hiera/path').and_return(true)
-          expect(function.lookup_key('path', options, context)).to eq('fullpath')
+          is_expected.to run.with_params('path', options, context).and_return('fullpath')
         end
 
         it 'find string using another region' do
@@ -98,7 +95,7 @@ describe TF do # rubocop:disable RSpec/FilePath
           allow(context).to receive(:cache).with('region2' => 'ohio')
           expect(context).to receive(:cached_value).with('region2').and_return('ohio')
           expect(context).to receive(:cache_has_key).with('region2').and_return(true)
-          expect(function.lookup_key('region2', options, context)).to eq('ohio')
+          is_expected.to run.with_params('region2', options, context).and_return('ohio')
         end
       end
     end

--- a/spec/spec_helper_local.rb
+++ b/spec/spec_helper_local.rb
@@ -1,9 +1,0 @@
-class TF
-  def self.dispatch(*); end
-end
-
-module Puppet::Functions
-  def self.create_function(_name, &block)
-    TF.class_eval(&block)
-  end
-end


### PR DESCRIPTION
The old way causes all other types of spec tests generated with `pdk new` to fail with wrong number of arguments errors. I suspect its due to overwriting Puppet::Function.

Anyway, this seems more standard and similar to what I have seen for other function tests in puppetlabs modules