### PR TITLE
Add read write no hiera

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The server needs access to describe and get keys on AWS. You can use an `instanc
             "Sid": "Stmt1526212635512",
             "Effect": "Allow",
             "Action": [
+                "ssm:PutParameter", # -> only if you want write
                 "ssm:GetParametersByPath",
                 "ssm:GetParameters"
             ],
@@ -86,6 +87,25 @@ AWS impose rate limit for API call, depending on the number of keys and nodes yo
 #### Upgrading from version 0.1.x
 
 Requires to update the IAM policy to use the option get_all
+
+### As Puppet Functions
+
+This module now also supports reading and writing ssm parameters as puppet functions within pp files.
+
+```puppet
+$options = {
+  'uri'     => '/',
+  'region'  => 'us-east-1',
+  'get_all' => false,
+  'put'     => { 'description' => 'Added by hiera_ssm_paramstore_write' },
+}
+$ssm_w_value = hiera_ssm_paramstore_write('/my/param', 'value', $options)
+$ssm_r_value = hiera_ssm_paramstore('/my/param', $options)
+```
+
+#### Put options
+
+[All options listed here](https://docs.aws.amazon.com/sdk-for-ruby/v2/api/Aws/SSM/Client.html#put_parameter-instance_method)
 
 ### Author
 

--- a/lib/puppet/functions/hiera_ssm_paramstore.rb
+++ b/lib/puppet/functions/hiera_ssm_paramstore.rb
@@ -35,7 +35,7 @@ Puppet::Functions.create_function(:hiera_ssm_paramstore) do
         return context.not_found
       end
     else
-      result = get_parameter(key, options, context, key_path)
+      result = get_parameter(key_path, options, context)
       return result
     end
   end
@@ -78,7 +78,7 @@ Puppet::Functions.create_function(:hiera_ssm_paramstore) do
     end
   end
 
-  def get_parameter(_key, options, context, key_path)
+  def get_parameter(key_path, options, context)
     ssmclient = ssm_get_connection(options)
 
     if context && context.cache_has_key(key_path)

--- a/lib/puppet/functions/hiera_ssm_paramstore_write.rb
+++ b/lib/puppet/functions/hiera_ssm_paramstore_write.rb
@@ -1,0 +1,71 @@
+Puppet::Functions.create_function(:hiera_ssm_paramstore_write) do
+  begin
+    require 'aws-sdk-ssm'
+  rescue LoadError
+    raise Puppet::DataBinding::LookupError, 'Must install gem aws-sdk-ssm to use hiera_ssm_paramstore'
+  end
+
+  dispatch :write_key do
+    param 'Variant[String, Numeric]', :key
+    param 'Variant[String, Numeric]', :value
+    param 'Hash', :options
+  end
+
+  def write_key(key, value, options)
+    key_path = options['uri'] + key.gsub('::', '/')
+
+    put_parameter(key_path, value, options)
+    # Fetch the newly created item. This both tests the creation and yields the result
+    # in the expected format.
+    result = get_parameter(key_path, options)
+    return result
+  end
+
+  def ssm_get_connection(options)
+    if options['region'].nil?
+      Aws::SSM::Client.new
+    else
+      Aws::SSM::Client.new(region: options['region'])
+    end
+  rescue Aws::SSM::Errors::ServiceError => e
+    raise Puppet::DataBinding::LookupError, "Fail to connect to aws ssm #{e.message}"
+  end
+
+  def put_parameter(key_path, value, options)
+    ssmclient = ssm_get_connection(options)
+    put_options = { name: key_path,
+                    description: 'Added by hiera_ssm_paramstore_write',
+                    value: value,
+                    tags: [
+                      {
+                        key: "CreatedBy",
+                        value: "puppet",
+                      },
+                    ],
+    }
+    put_options = put_options.merge(options['put']) if options['put']
+
+    begin
+      resp = ssmclient.put_parameter(put_options)
+    rescue Aws::SSM::Errors::ServiceError => e
+      raise Puppet::DataBinding::LookupError, "AWS SSM Service error #{e.message}"
+    end
+  end
+
+  def get_parameter(key_path, options)
+    ssmclient = ssm_get_connection(options)
+
+    begin
+      resp = ssmclient.get_parameters(names: [key_path],
+                                      with_decryption: true)
+      if !resp.parameters.empty?
+        value = resp.parameters[0].value
+        return value
+      else
+        return nil
+      end
+    rescue Aws::SSM::Errors::ServiceError => e
+      raise Puppet::DataBinding::LookupError, "AWS SSM Service error #{e.message}"
+    end
+  end
+end

--- a/spec/functions/hiera_ssm_paramstore_spec.rb
+++ b/spec/functions/hiera_ssm_paramstore_spec.rb
@@ -47,56 +47,88 @@ describe 'hiera_ssm_paramstore' do
         expect(context).to receive(:interpolate).with('/plain/translate').and_return('/plain/translate')
         is_expected.to run.with_params('plain::translate', options, context).and_return('parameter_value')
       end
-      context 'Should run fetching all keys' do
-        let(:options) do
-          {
-            'uri' => '/',
-            'region' => 'us-east-1',
-            'get_all' => true,
-            'recursive' => true,
-          }
-        end
+    end
 
-        it 'find string' do
-          expect(context).to receive(:interpolate).with('/plain').and_return('/plain')
-          allow(context).to receive(:cache).with('plain' => 'value_plain')
-          expect(context).to receive(:cached_value).with('plain').and_return('value_plain')
-          expect(context).to receive(:cache_has_key).with('plain').and_return(true)
-          is_expected.to run.with_params('plain', options, context).and_return('value_plain')
-        end
+    context 'Should run without a hiera context' do
+      let(:options) do
+        {
+          'uri' => '/',
+          'region' => 'us-east-1',
+          'get_all' => false,
+        }
+      end
 
-        it 'find secure string' do
-          expect(context).to receive(:interpolate).with('/encrypted').and_return('/encrypted')
-          allow(context).to receive(:cache).with('encrypted' => 'value_encrypted')
-          expect(context).to receive(:cached_value).with('encrypted').and_return('value_encrypted')
-          expect(context).to receive(:cache_has_key).with('encrypted').and_return(true)
-          is_expected.to run.with_params('encrypted', options, context).and_return('value_encrypted')
-        end
+      it 'find string' do
+        is_expected.to run.with_params('plain', options).and_return('value_plain')
+      end
 
-        it 'not find value' do
-          expect(context).to receive(:interpolate).with('/nonexists').and_return('/nonexists')
-          expect(context).to receive(:cache_has_key).with('nonexists').and_return(false)
-          expect(context).to receive(:not_found)
-          is_expected.to run.with_params('nonexists', options, context).and_return(nil)
-        end
+      it 'find secure string' do
+        is_expected.to run.with_params('encrypted', options).and_return('value_encrypted')
+      end
 
-        it 'find string full path' do
-          options['uri'] = '/hiera/'
-          expect(context).to receive(:interpolate).with('/hiera/path').and_return('/hiera/path')
-          allow(context).to receive(:cache).with('/hiera/path' => 'fullpath')
-          expect(context).to receive(:cached_value).with('/hiera/path').and_return('fullpath')
-          expect(context).to receive(:cache_has_key).with('/hiera/path').and_return(true)
-          is_expected.to run.with_params('path', options, context).and_return('fullpath')
-        end
+      it 'not find value' do
+        is_expected.to run.with_params('nonexists', options).and_return(nil)
+      end
 
-        it 'find string using another region' do
-          options['region'] = 'us-east-2'
-          expect(context).to receive(:interpolate).with('/region2').and_return('/region2')
-          allow(context).to receive(:cache).with('region2' => 'ohio')
-          expect(context).to receive(:cached_value).with('region2').and_return('ohio')
-          expect(context).to receive(:cache_has_key).with('region2').and_return(true)
-          is_expected.to run.with_params('region2', options, context).and_return('ohio')
-        end
+      it 'find string using another region' do
+        options['region'] = 'us-east-2'
+        is_expected.to run.with_params('region2', options).and_return('ohio')
+      end
+
+      it 'find translate string' do
+        is_expected.to run.with_params('plain::translate', options).and_return('parameter_value')
+      end
+    end
+
+    context 'Should run fetching all keys' do
+      let(:options) do
+        {
+          'uri' => '/',
+          'region' => 'us-east-1',
+          'get_all' => true,
+          'recursive' => true,
+        }
+      end
+
+      it 'find string' do
+        expect(context).to receive(:interpolate).with('/plain').and_return('/plain')
+        allow(context).to receive(:cache).with('plain' => 'value_plain')
+        expect(context).to receive(:cached_value).with('plain').and_return('value_plain')
+        expect(context).to receive(:cache_has_key).with('plain').and_return(true)
+        is_expected.to run.with_params('plain', options, context).and_return('value_plain')
+      end
+
+      it 'find secure string' do
+        expect(context).to receive(:interpolate).with('/encrypted').and_return('/encrypted')
+        allow(context).to receive(:cache).with('encrypted' => 'value_encrypted')
+        expect(context).to receive(:cached_value).with('encrypted').and_return('value_encrypted')
+        expect(context).to receive(:cache_has_key).with('encrypted').and_return(true)
+        is_expected.to run.with_params('encrypted', options, context).and_return('value_encrypted')
+      end
+
+      it 'not find value' do
+        expect(context).to receive(:interpolate).with('/nonexists').and_return('/nonexists')
+        expect(context).to receive(:cache_has_key).with('nonexists').and_return(false)
+        expect(context).to receive(:not_found)
+        is_expected.to run.with_params('nonexists', options, context).and_return(nil)
+      end
+
+      it 'find string full path' do
+        options['uri'] = '/hiera/'
+        expect(context).to receive(:interpolate).with('/hiera/path').and_return('/hiera/path')
+        allow(context).to receive(:cache).with('/hiera/path' => 'fullpath')
+        expect(context).to receive(:cached_value).with('/hiera/path').and_return('fullpath')
+        expect(context).to receive(:cache_has_key).with('/hiera/path').and_return(true)
+        is_expected.to run.with_params('path', options, context).and_return('fullpath')
+      end
+
+      it 'find string using another region' do
+        options['region'] = 'us-east-2'
+        expect(context).to receive(:interpolate).with('/region2').and_return('/region2')
+        allow(context).to receive(:cache).with('region2' => 'ohio')
+        expect(context).to receive(:cached_value).with('region2').and_return('ohio')
+        expect(context).to receive(:cache_has_key).with('region2').and_return(true)
+        is_expected.to run.with_params('region2', options, context).and_return('ohio')
       end
     end
   end

--- a/spec/functions/hiera_ssm_paramstore_write_spec.rb
+++ b/spec/functions/hiera_ssm_paramstore_write_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe 'hiera_ssm_paramstore_write' do
+  describe 'write_key' do
+    context 'Should run without a hiera context' do
+      let(:options) do
+        {
+          'uri' => '/',
+          'region' => 'us-east-1',
+          'get_all' => false,
+          'put' => { overwrite: true, tags: nil },
+        }
+      end
+
+      it 'write string' do
+        is_expected.to run.with_params('write/plain', 'write:value_plain', options).and_return('write:value_plain')
+      end
+
+      it 'write secure string' do
+        options['put'] = { type: 'SecureString', overwrite: true, tags: nil }
+        is_expected.to run.with_params('write/encrypted', 'write:value_encrypted', options).and_return('write:value_encrypted')
+      end
+
+      it 'write same key' do
+        options['put'] = { overwrite: false }
+        is_expected.to run.with_params('write/plain', 'write:value_plain', options).and_raise_error(Puppet::DataBinding::LookupError)
+      end
+
+      it 'write string using another region' do
+        options['region'] = 'us-east-2'
+        is_expected.to run.with_params('write/region2', 'write:ohio', options).and_return('write:ohio')
+      end
+
+      it 'write translate string' do
+        is_expected.to run.with_params('write::plain::translate', 'write:parameter_value', options).and_return('write:parameter_value')
+      end
+    end
+  end
+end


### PR DESCRIPTION
This makes hiera context optional when using the lookup function and adds a write function without hiera context.

This is to allow interacting with ssm parameters without hiera via native puppet function calls.